### PR TITLE
Update package.json to define main entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   ],
   "license": "MIT",
   "author": "bohdanbirdie",
+  "main": "./dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.js"


### PR DESCRIPTION
Currently this package can't be imported with the older `node` module resolver.

It defines the ES module entrypoint and we use [node as our module resolution](https://nodejs.org/api/modules.html#folders-as-modules), which errors because of the following:

> If there is no package.json file present in the directory, or if the main entry is missing or cannot be resolved, then Node.js will attempt to load an index.js or index.node file out of that directory.

> If these attempts fail, then Node.js will report the entire module as missing with the default error: Error: Cannot find module 'some-library'

This change defines the main entry point via the `main` field, which can coexist with the export field.